### PR TITLE
Local webmap

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -19,6 +19,37 @@ define({
     //Default configuration settings for the application. This is where you'll define things like a bing maps key,
     //default web map, default app color theme and more. These values can be overwritten by template configuration settings and url parameters.
     "appid": "",
+    //Use "itemInfo" if you want to define a local webmap instead of relying on AGOL.
+    "itemInfo": {
+      "item": {
+        "title": "Soil Survey Map of USA",
+        "snippet": "Detailed description of data",
+        "extent": [[-139.4916, 10.7191], [-52.392, 59.5199]]
+      },
+      "itemData": {
+        "operationalLayers": [{
+          "url": "http://server.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer",
+          "visibility": true,
+          "opacity": 0.75,
+          "title": "Soil Survey Map",
+          "itemId": "204d94c9b1374de9a21574c9efa31164"
+  				}],
+        "baseMap": {
+          "baseMapLayers": [{
+            "opacity": 1,
+            "visibility": true,
+            "url": "http://services.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer"
+  					}, {
+            "isReference": true,
+            "opacity": 1,
+            "visibility": true,
+            "url": "http://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Reference_Overlay/MapServer"
+  					}],
+          "title": "World_Terrain_Base"
+        },
+        "version": "1.1"
+      }
+    },
     "webmap": "24e01ef45d40423f95300ad2abc5038a",
     "oauthappid": null, //"AFTKRmv16wj14N3z",
     //Group templates must support a group url parameter. This will contain the id of the group.

--- a/js/template.js
+++ b/js/template.js
@@ -114,8 +114,8 @@ array, declare, kernel, lang, Evented, Deferred, string, domClass, all, esriConf
                     this._mixinAll();
                     // then execute these async
                     all({
-                        // webmap item
-                        item: this.queryItem(),
+                        // get item data from local config or from ArcGIS.com
+                        item: this.config.itemInfo || this.queryItem(),
                         // group information
                         groupInfo: this.queryGroupInfo(),
                         // group items


### PR DESCRIPTION
These small changes allow to use a locally defined webmap instead of using a webmap id from AGOL.

Adapted from these commits:
- jsomerville/Viewer@9d5b8e14ee36ac1ef6888b277c0a65e61adfa738
- jsomerville/Viewer@476da3aaade082109c87496233f324d5acbef72f
